### PR TITLE
CI Cronjob Enhancements

### DIFF
--- a/.cicd/manifests/cronjob.yaml
+++ b/.cicd/manifests/cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  namespace: {{.Values.namespace}}
+  name: {{.Values.appName}}-{{.Values.envName}}-cron
+spec:
+  schedule: "*/1 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 120
+  failedJobsHistoryLimit: 30
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{.Values.appName}}-{{.Values.envName}}-cron
+            image: {{.Values.artifactImage}}
+            args:
+            - /bin/sh
+            - -c
+            - php /app/crontab/cron.php
+            envFrom:
+            - configMapRef:
+                name: {{.Values.appName}}-{{.Values.envName}}-config
+            resources:
+              requests:
+                cpu: "100m"
+                memory: "100Mi"
+              limits:
+                cpu: "200m"
+                memory: "200Mi"
+          restartPolicy: Never

--- a/.cicd/values/backend-prod.yaml
+++ b/.cicd/values/backend-prod.yaml
@@ -1,5 +1,5 @@
 #Deployment
-replicaCount: 1
+replicaCount: 3
 
 #Pod
 resourceCpuRequest: 1000m

--- a/.cicd/values/backend-staging.yaml
+++ b/.cicd/values/backend-staging.yaml
@@ -1,5 +1,5 @@
 #Deployment
-replicaCount: 1
+replicaCount: 3
 
 #Pod
 resourceCpuRequest: 1000m


### PR DESCRIPTION
# CI Cronjob Enhancements

This PR introduces two significant changes:

1. [Commit: f03b8e7](https://github.com/casper-network/CasperAssociationPortalBackend/commit/f03b8e78b462d8dc1f45c4072a0d574d349e87eb) - "ci: increasing replica now possible thanks to k8s cron"
   - This commit enables the ability to increase the replica count of our backend service. It's possible to do it now as we have the cronjob disabled on the containers and enabled through native K8S support

2. [Commit: f4a72f3](https://github.com/casper-network/CasperAssociationPortalBackend/commit/f4a72f3de8e4df298c99440b70b1e627c1775541) - "ci: adding cronjob"
   - This commit adds a new cron job to the CI pipeline. The cron job is defined in a Kubernetes `CronJob` resource. It runs every minute (`"*/1 * * * *"`), forbids concurrent runs, and keeps a history of the last 120 successful jobs and the last 30 failed jobs. The job runs a PHP script located at `/app/crontab/cron.php` in a container based on the `{{.Values.artifactImage}}` image. The container has specific CPU and memory requests and limits, and it uses environment variables from a ConfigMap named `{{.Values.appName}}-{{.Values.envName}}-config`. The pod's restart policy is `Never`, meaning that if the script fails, the container will not be restarted (No need to do so as the cron is run every minute).

