### PR TITLE
Bradjohnl ci fix perm after k8s upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ repos:
           - SC2086
           - --ignore
           - DL3059
+          - --ignore
+          - DL3018
           - Dockerfile
 
   # NGINX - validate config

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . ./
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/download/2.0.2/install-php-extensions /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/install-php-extensions \
-  && install-php-extensions gd \
+  && install-php-extensions gd gmp mysqli \
   && composer install --optimize-autoloader --no-interaction --no-progress --no-ansi \
   && composer dump-autoload --optimize
 
@@ -18,7 +18,7 @@ WORKDIR /app
 
 COPY --chown=nginx config/default.conf /etc/nginx/conf.d/default.conf
 
-RUN apk add --no-cache gcompat=1.1.0-r0 php81-gd php81-zip php81-mysqli php81-sqlite3 php81-gmp php81-bcmath \
+RUN apk add --no-cache gcompat=1.1.0-r0 php81-zip php81-mysqli php81-bcmath php81-gmp php81-sqlite3 \
   && rm -rf /var/www/html \
   && rm -rf /var/cache/apk/* \
   && chown -R nginx:nginx /app /var/lib/nginx /run

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,7 @@ RUN apk add --no-cache gcompat=1.1.0-r0 php81-gd php81-zip php81-mysqli php81-sq
 
 COPY --chown=nginx --from=build-php /app .
 
-RUN sed -i 's/;extension=gd/extension=gd/' /etc/php81/php.ini \
-  && sed -i 's/;extension=zip/extension=zip/' /etc/php81/php.ini \
-  && sed -i 's/;extension=mysqli/extension=mysqli/' /etc/php81/php.ini \
-  && sed -i 's/;extension=sqlite3/extension=sqlite3/' /etc/php81/php.ini \
-  && sed -i 's/;extension=gmp/extension=gmp/' /etc/php81/php.ini \
+RUN sed -i 's/;extension=zip/extension=zip/' /etc/php81/php.ini \
   && sed -i 's/;extension=bcmath/extension=bcmath/' /etc/php81/php.ini \
   && chmod -R 775 . \
   && chown -R nginx:nginx . \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ COPY --chown=nginx config/default.conf /etc/nginx/conf.d/default.conf
 RUN apk add --no-cache gcompat=1.1.0-r0 php81-gd php81-zip php81-mysqli php81-sqlite3 php81-gmp php81-bcmath \
   && rm -rf /var/www/html \
   && rm -rf /var/cache/apk/* \
-  && mkdir -p /app \
-  && chown -R nginx:nginx /app
+  && chown -R nginx:nginx /app /var/lib/nginx /run
 
 COPY --chown=nginx --from=build-php /app .
 
@@ -30,8 +29,8 @@ RUN sed -i 's/;extension=zip/extension=zip/' /etc/php81/php.ini \
   && sed -i 's/;extension=bcmath/extension=bcmath/' /etc/php81/php.ini \
   && chmod -R 775 . \
   && chown -R nginx:nginx . \
-  && addgroup nobody nginx
-
-USER nobody
+  && chown -R nginx:nginx /var/log/nginx
 
 EXPOSE 80
+
+USER nginx

--- a/config/default.conf
+++ b/config/default.conf
@@ -1,5 +1,12 @@
 server {
-    listen 80;
+    listen [::]:80 default_server;
+    listen 80 default_server;
+    server_name _;
+
+    sendfile off;
+    tcp_nodelay on;
+    absolute_redirect off;
+
     root /app/public;
 
     add_header X-Frame-Options "SAMEORIGIN";
@@ -41,13 +48,21 @@ server {
     error_page 404 /index.php;
 
     location ~ \.php$ {
-        fastcgi_pass unix:/var/run/php-fpm.sock;
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/run/php-fpm.sock;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_NAME $fastcgi_script_name;
         fastcgi_index index.php;
-        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;
     }
 
-    location ~ /\.(?!well-known).* {
+    location ~* \.(jpg|jpeg|gif|png|css|js|ico|xml)$ {
+        expires 5d;
+    }
+
+    location ~ /\. {
+        log_not_found off;
         deny all;
     }
 }


### PR DESCRIPTION
- Ignored rule DL3018 to avoid version pinning.
- Removed duplicate extension loads in the CI configuration.
- Fixed permission issues that arose after the Kubernetes upgrade.